### PR TITLE
Add closing help thread status

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -46,6 +46,7 @@ HELP_TOPIC_EMOJIS: Dict[str, str] = {
     "🤚": "Help Needed",
     "🔥": "Active",
     "⏳": "Stalled",
+    "⏱️": "Closing",
     "🛠️": "Development Version",
     "🐛": "Bug Report",
     "📌": "Pinned",


### PR DESCRIPTION
Add ⏱️ Closing status to help threads to indicate that the thread is to be closed soon. I guess we can close threads with this status after 12/24 hours unless the author sends something useful.

The current solution is to mark the thread as stalled.